### PR TITLE
Load Supabase config via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ location / {
 to your Nginx config if routes should resolve to `index.html`.
 
 ## Supabase Credentials
-Update `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `stack.env` or via environment variables. The frontend creates the Supabase client using these values.
+The application requires two environment variables for the Supabase client:
+
+```
+VITE_SUPABASE_URL
+VITE_SUPABASE_ANON_KEY
+```
+
+Set them in `stack.env`, a local `.env` file or as environment variables when running Docker. The client in `customSupabaseClient.js` reads these values via `import.meta.env`.
 
 ## Basic Scan Webhook
 When running a scan, the app invokes the Supabase function `n8n-proxy` with payload:

--- a/src/lib/customSupabaseClient.js
+++ b/src/lib/customSupabaseClient.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://thceupkmlmusckmveele.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRoY2V1cGttbG11c2NrbXZlZWxlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgxMDY0NDgsImV4cCI6MjA2MzY4MjQ0OH0.Zrb8fGdBm6M8gO-fYtOd-mMO7n3X7OYFhdZk7Px1DQQ';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- load Supabase credentials from environment variables
- document required env vars in README

## Testing
- `npm run lint` *(fails: No files matching the pattern)*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868395f05b08325a687449dd7630ddc