### PR TITLE
Use env var for Stripe publishable key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Environment variables:
   - `VITE_SUPABASE_URL` – your Supabase project URL
   - `VITE_SUPABASE_ANON_KEY` – the Supabase anonymous key
-  - (optional) `VITE_STRIPE_PUBLISHABLE_KEY` for Stripe integration
+  - `VITE_STRIPE_PUBLISHABLE_KEY` – your Stripe publishable key
 
 ## Local Development
 1. Install dependencies:
@@ -26,6 +26,7 @@ docker build -t rfx-audit-v4 .
 docker run -p 3002:80 \
   -e VITE_SUPABASE_URL=https://yourproject.supabase.co \
   -e VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY \
+  -e VITE_STRIPE_PUBLISHABLE_KEY=YOUR_STRIPE_KEY \
   rfx-audit-v4
 ```
 Alternatively, use `docker-compose`:
@@ -41,7 +42,7 @@ location / {
 to your Nginx config if routes should resolve to `index.html`.
 
 ## Supabase Credentials
-Update `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `stack.env` or via environment variables. The frontend creates the Supabase client using these values.
+Update `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and `VITE_STRIPE_PUBLISHABLE_KEY` in `stack.env` or via environment variables. The frontend creates the Supabase and Stripe clients using these values.
 
 ## Basic Scan Webhook
 When running a scan, the app invokes the Supabase function `n8n-proxy` with payload:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - VITE_SUPABASE_URL=https://yourproject.supabase.co
       - VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+      - VITE_STRIPE_PUBLISHABLE_KEY=pk_test_YOUR_KEY
     networks:
       - core-services_stack_proxy-tier
 

--- a/src/pages/PricingPage.jsx
+++ b/src/pages/PricingPage.jsx
@@ -10,9 +10,7 @@ import { useAuth } from '@/contexts/SupabaseAuthContext';
 import { loadStripe } from '@stripe/stripe-js';
 import { supabase } from '@/lib/customSupabaseClient';
 
-// **ACTION REQUIRED**: Replace with your actual Stripe publishable key
-const STRIPE_PUBLISHABLE_KEY = "pk_test_YOUR_PUBLISHABLE_KEY"; 
-const stripePromise = loadStripe(STRIPE_PUBLISHABLE_KEY);
+const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY);
 
 const PricingCard = ({ plan, onSelectPlan, isCurrentPlan, loadingPlan }) => (
   <Card className={`flex flex-col h-full ${isCurrentPlan ? 'border-crimson shadow-crimson/20' : ''}`}>


### PR DESCRIPTION
## Summary
- read Stripe key from `import.meta.env` in Pricing page
- add `VITE_STRIPE_PUBLISHABLE_KEY` to docker-compose example
- document Stripe env var in README

## Testing
- `npm run lint` *(fails: No files matching the pattern)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68683978aab083258387e57bb50f51bf