### PR TITLE
Update compose env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,17 @@ version: '3.8'
 services:
   frontend:
     container_name: rfx-audit-v4
+    env_file: stack.env
     build:
       context: .
       args:
-        - VITE_SUPABASE_URL
-        - VITE_SUPABASE_ANON_KEY
-        - VITE_STRIPE_PUBLISHABLE_KEY
+        VITE_SUPABASE_URL: ${VITE_SUPABASE_URL}
+        VITE_SUPABASE_ANON_KEY: ${VITE_SUPABASE_ANON_KEY}
+        VITE_STRIPE_PUBLISHABLE_KEY: ${VITE_STRIPE_PUBLISHABLE_KEY}
+    environment:
+      VITE_SUPABASE_URL: ${VITE_SUPABASE_URL}
+      VITE_SUPABASE_ANON_KEY: ${VITE_SUPABASE_ANON_KEY}
+      VITE_STRIPE_PUBLISHABLE_KEY: ${VITE_STRIPE_PUBLISHABLE_KEY}
     restart: always
     ports:
       - "3002:80"  # External port → internal nginx static server


### PR DESCRIPTION
## Summary
- add `stack.env` as an env_file for the `frontend` service
- supply build args from environment variables
- expose the same variables at runtime via `environment`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_686af90c431c83259c3d349b9ac479e0