### PR TITLE
Add Docker deployment files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+Dockerfile
+docker-compose.yml
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log*
+dist
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use node 20 for building the app
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Serve the built static files
+FROM node:20-alpine
+WORKDIR /app
+RUN npm install -g serve
+COPY --from=build /app/dist ./dist
+EXPOSE 4173
+CMD ["serve", "-s", "dist", "-l", "4173"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ npm run preview      # serve built assets for testing
 
 ## Docker
 
-A Dockerfile is not provided, but the app can be containerised. Build an image using Node 20, copy the project files, run `npm install` followed by `npm run build`, and serve the `dist/` directory with a static file server such as `serve` or Nginx.
+This repository now includes a Dockerfile and compose file for easy deployment. The image builds the production assets using Node 20 and serves the `dist/` directory with `serve`.
+
+### Local usage
+
+```bash
+docker compose up --build
+```
+
+The container listens on port `4173` (mapped to `8080` by default in `docker-compose.yml`). Portainer can deploy the stack directly from this repository using the compose file.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+services:
+  web:
+    build: .
+    ports:
+      - "8080:4173"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Dockerfile to build and serve Vite output
- add docker-compose.yml for easy container startup
- ignore build and dependency folders
- document Docker usage in README

## Testing
- `npm run lint` *(fails: No files matching)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687154d719208325a0f5ff633031e08b